### PR TITLE
improve: update traba code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,21 @@ HTTPS enforcement with automatic HTTP to HTTPS redirect
 task deploy:pulumi PROJECT=fs0ciety ENV=prod
 
 be aware the the terraform CI/CD are inthe .github/workflows-archived. if you want ot use them in CI then you have to move those file back into githubworkflows 
+
+
+To start locally: 
+open up 3 terminals 
+
+docker build 
+npm run dev 
+go run main.go 
+
+ngrok 8080 (this is for the webhook)
+
+
+before running task deploy:pulumi you have to make sure to set at least 1 value in in prod secrets manager 
+
+
+
+for ssm tunneling into db run: brew install session-manager-plugin
+

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,8 @@ vars:
   PROJECT: '{{ default "fs0ciety" .PROJECT }}'
   ENV: '{{ .ENV }}'
   AWS_REGION: '{{ default "us-east-1" .AWS_REGION }}'
+  PULUMI_BASE_STACK: '{{ default (printf "rasha-hantash-org/%sbase/%s" .PROJECT .ENV) .PULUMI_BASE_STACK }}'
+  PULUMI_BASE_DIR: '{{ default "platform/infra-pulumi/base" .PULUMI_BASE_DIR }}'
 
   # example: 2026-01-02_13H05M-ab12cd3
   TAG:
@@ -94,14 +96,14 @@ tasks:
       # create the same style tag you use elsewhere
       PREVIEW_TAG: "preview-{{.TAG}}"
 
-      FRONTEND_IMAGE: "{{.ECR_URI}}:frontend-{{.PREVIEW_TAG}}"
-      BACKEND_IMAGE: "{{.ECR_URI}}:backend-{{.PREVIEW_TAG}}"
+      FRONTEND_IMAGE_TAG: "frontend-{{.PREVIEW_TAG}}"
+      BACKEND_IMAGE_TAG: "backend-{{.PREVIEW_TAG}}"
     cmds:
       - pulumi stack select {{.PULUMI_STACK}}
       - pulumi config set awsRegion {{.AWS_REGION}}
       - pulumi config set baseStack "rasha-hantash-org/fs0cietybase/{{.ENV}}"
-      - pulumi config set frontendImage {{.FRONTEND_IMAGE}}
-      - pulumi config set backendImage {{.BACKEND_IMAGE}}
+      - pulumi config set frontendImageTag {{.FRONTEND_IMAGE_TAG }}
+      - pulumi config set backendImageTag {{.BACKEND_IMAGE_TAG }}
       - pulumi preview
 
   pulumi:up:
@@ -110,15 +112,15 @@ tasks:
     vars:
       ECR_URI:
         sh: task fetch-ecr-uri PROJECT={{.PROJECT}} ENV={{.ENV}} AWS_REGION={{.AWS_REGION}}
-      FRONTEND_IMAGE: "{{.ECR_URI}}:frontend-{{.TAG}}"
-      BACKEND_IMAGE: "{{.ECR_URI}}:backend-{{.TAG}}"
+      FRONTEND_IMAGE_TAG: "frontend-{{.TAG}}"
+      BACKEND_IMAGE_TAG: "backend-{{.TAG}}"
     cmds:
       # select stack (assumes it already exists; add `pulumi stack init` if you want)
       - pulumi stack select {{.PULUMI_STACK}}
       # set ephemeral config (these keys should match what your pulumi code reads)
       - pulumi config set awsRegion {{.AWS_REGION}}
-      - pulumi config set frontendImage {{.FRONTEND_IMAGE}}
-      - pulumi config set backendImage {{.BACKEND_IMAGE}}
+      - pulumi config set frontendImageTag {{.FRONTEND_IMAGE_TAG}}
+      - pulumi config set backendImageTag {{.BACKEND_IMAGE_TAG}}
       - pulumi up --yes
 
   pulumi:up:fe:
@@ -165,6 +167,45 @@ tasks:
     cmds:
       - task: backend:docker
       - task: pulumi:up:be
+
+  
+  local:ssm:tunnel:db:
+    desc: "Open SSM port-forward tunnel to private RDS via the SSM db-access instance (keep running)"
+    # dir: "{{.PULUMI_BASE_DIR}}"
+    vars:
+      LOCAL_PORT: "5439"
+      DB_PORT: "5432"
+
+      INSTANCE_ID:
+        sh: pulumi -C platform/infra-pulumi/base stack output ssmDbAccessInstanceId --stack prod
+      DB_ENDPOINT:
+        sh: pulumi -C platform/infra-pulumi/base stack output dbEndpoint --stack prod
+    cmds:
+      - |
+        aws ssm start-session \
+          --region {{.AWS_REGION}} \
+          --target {{.INSTANCE_ID}} \
+          --document-name AWS-StartPortForwardingSessionToRemoteHost \
+          --parameters "host={{.DB_ENDPOINT}},portNumber={{.DB_PORT}},localPortNumber={{.LOCAL_PORT}}"
+
+
+
+  local:ssm:migrate:up:
+    desc: "Run DB migrations against localhost tunnel (requires local:ssm:tunnel:db running)"
+    vars:
+      LOCAL_PORT: "5439"
+      DB_NAME: "fs0ciety" # or make it configurable
+      DB_USER: "fs0ciety_admin"
+      DB_PASS_ENC: "{{.DB_PASS_ENC}}"
+    requires:
+      vars: [PROJECT, ENV, AWS_REGION, DB_PASS_ENC]
+    cmds:
+      - |
+        migrate -path platform/sql/migrations/ \
+          -database "postgres://{{.DB_USER}}:{{.DB_PASS_ENC}}@localhost:{{.LOCAL_PORT}}/{{.DB_NAME}}?sslmode=require" \
+          -verbose up
+
+
 
   # ---------- terraform deploy (optional legacy path) ----------
   terraform:apply:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=your_password
-      - POSTGRES_DB=traba
+      - POSTGRES_DB=fs0ciety
     ports:
       - '5438:5432'
     volumes:

--- a/docker/Dockerfile.be
+++ b/docker/Dockerfile.be
@@ -6,7 +6,7 @@ RUN go mod download && go mod tidy
 RUN go build -v -o /usr/local/bin/api
 
 FROM golang:1.23.1
-ARG ENV=staging
+ARG ENV=local
 ENV ENV=$ENV
 COPY --from=build /usr/local/bin/api /usr/local/bin/api
 ENTRYPOINT ["/usr/local/bin/api"]

--- a/docker/Dockerfile.fe
+++ b/docker/Dockerfile.fe
@@ -2,7 +2,7 @@ FROM node:22-alpine
 WORKDIR /app
 COPY frontend/ .
 RUN npm install
-ARG ENV=staging
+ARG ENV=local
 ENV ENV=$ENV
 ENV PORT=80
 RUN npm run build

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,9 @@ AUTH0_CLIENT_SECRET='auth0-client-secret'
 MY_REDIRECT_SECRET='andom-open-ssl-secret'
 AUTH0_MANAGEMENT_CLIENT_ID='auth0-management-client-id'
 AUTH0_MANAGEMENT_CLIENT_SECRET='auth0-management-client-secret'
+
+
+# refer to your aws administrator for credentials
+AWS_REGION='your-aws-region'
+AWS_ACCESS_KEY_ID='your-aws-access-key-id'
+AWS_SECRET_ACCESS_KEY='your-aws-secret-access-key'

--- a/frontend/app/api/config.ts
+++ b/frontend/app/api/config.ts
@@ -1,5 +1,5 @@
 export const config = {
-    apiUrl: process.env.API_URL || 'http://localhost:8000',
+    apiUrl: process.env.API_URL || 'http://localhost:8080',
     // Add other API-related configuration here
   };
   

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -1,6 +1,0 @@
-// app/api/health/route.ts
-import { NextResponse } from 'next/server'
-
-export async function GET() {
-  return NextResponse.json({ status: 'healthy' })
-}

--- a/frontend/app/api/secrets/route.ts
+++ b/frontend/app/api/secrets/route.ts
@@ -15,16 +15,16 @@ export async function GET() {
 
   const client = new SecretsManagerClient({ 
     region: process.env.AWS_REGION,
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!
-    }
+    // credentials: {
+    //   accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    //   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!
+    // }
   });
 
   try {
     const response = await client.send(
       new GetSecretValueCommand({
-        SecretId: `traba-${process.env.ENV}-frontend-config`,
+        SecretId: `fs0ciety-${process.env.ENV}-core-config`,
       })
     );
 

--- a/frontend/app/health/route.ts
+++ b/frontend/app/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs"; // safe default on ECS
+
+export async function GET() {
+  return NextResponse.json({ status: "ok" }, { status: 200 });
+}

--- a/frontend/utils/getSecrets.ts
+++ b/frontend/utils/getSecrets.ts
@@ -6,16 +6,16 @@ export async function getAwsSecrets() {
 
   const client = new SecretsManagerClient({ 
     region: process.env.AWS_REGION,
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!
-    }
+    // credentials: {
+    //   accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    //   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!
+    // }
   });
 
   try {
     const response = await client.send(
       new GetSecretValueCommand({
-        SecretId: `traba-${environment}-frontend-config`,
+        SecretId: `fs0ciety-${environment}-core-config`,
       })
     );;
 

--- a/platform/api/config/config.go
+++ b/platform/api/config/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Config struct {
-	ServerPort         string `json:"PORT"`
+	ServerPort         string `json:"BACKEND_PORT"`
 	DBConnString       string `json:"CONN_STRING"`
 	Auth0Secret        string `json:"AUTH0_SECRET"`
 	Auth0Domain        string `json:"AUTH0_DOMAIN"`
@@ -31,10 +31,12 @@ func LoadConfig(ctx context.Context) (*Config, error) {
 	if env == "" {
 		env = "local"
 	}
+
 	slog.InfoContext(ctx, "loading config", "env", env)
 
 	region := "us-east-1"
-	secretName := fmt.Sprintf("traba-%s-backend-config", env)
+	// secretName := fmt.Sprintf("%s-%s-core-config", projectName, env)
+	secretName := fmt.Sprintf("fs0ciety-%s-core-config", env)
 
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),

--- a/platform/api/main.go
+++ b/platform/api/main.go
@@ -19,39 +19,6 @@ import (
 	"github.com/rs/cors"
 )
 
-type Auth0Config struct {
-	Auth0Secret        string `env:"AUTH0_SECRET"`
-	Auth0Domain        string `env:"AUTH0_DOMAIN"`
-	Auth0BaseURL       string `env:"AUTH0_BASE_URL"`
-	Auth0IssuerBaseURL string `env:"AUTH0_ISSUER_BASE_URL"`
-	Auth0ClientID      string `env:"AUTH0_CLIENT_ID"`
-	Auth0ClientSecret  string `env:"AUTH0_CLIENT_SECRET"`
-	Auth0RoleID        string `env:"AUTH0_ROLE_ID"`
-	Auth0Audience      string `env:"AUTH0_AUDIENCE"`
-	Auth0HookSecret    string `env:"AUTH_HOOK_SECRET"`
-}
-
-type DatabaseConfig struct {
-	// todo update the connection string to be localhost, postgres, or whatever the host name is supposed to be
-	ConnString string `env:"CONN_STRING"`
-}
-
-// type Auth
-
-type Config struct {
-	ServerPort         string `json:"PORT"`
-	DBConnString       string `json:"CONN_STRING"`
-	Auth0Secret        string `json:"AUTH0_SECRET"`
-	Auth0Domain        string `json:"AUTH0_DOMAIN"`
-	Auth0BaseURL       string `json:"AUTH0_BASE_URL"`
-	Auth0IssuerBaseURL string `json:"AUTH0_ISSUER_BASE_URL"`
-	Auth0ClientID      string `json:"AUTH0_CLIENT_ID"`
-	Auth0ClientSecret  string `json:"AUTH0_CLIENT_SECRET"`
-	Auth0RoleID        string `json:"AUTH0_ROLE_ID"`
-	Auth0Audience      string `json:"AUTH0_AUDIENCE"`
-	Auth0HookSecret    string `json:"AUTH_HOOK_SECRET"`
-}
-
 // todo add logger later on
 func main() {
 	ctx := context.Background()
@@ -86,11 +53,9 @@ func main() {
 		AllowCredentials: true,
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-TOKEN"},
 		AllowedOrigins: []string{
-			// "*", // todo remove this
 			"http://localhost:3000",
 			"http://127.0.0.1:3000",
-			"https://traba-staging.fs0ciety.dev",
-			// "https://app.getclaimclam.com",
+			"https://app.fs0ciety.dev",
 		},
 		// Debug: true,
 	}).Handler)
@@ -133,6 +98,7 @@ func NewDBClient(psqlConnStr string) (*sql.DB, error) {
 	//     u.Host,
 	//     u.Path,
 	// )
+	slog.Info("psqlConnStr", "psqlConnStr", psqlConnStr)
 	db, err := sql.Open("postgres", psqlConnStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)

--- a/platform/infra-pulumi/base/main.go
+++ b/platform/infra-pulumi/base/main.go
@@ -25,7 +25,7 @@ func main() {
 			VpcCidr:      cfg.VpcCidr,
 			PublicCount:  2,
 			PrivateCount: 2,
-			NewBits:      7, // matches your old terraform cidrsubnet(newbits=7)
+			NewBits:      7, // matches terraform's cidrsubnet(newbits=7)
 		})
 		if err != nil {
 			return err

--- a/platform/infra-pulumi/base/pkg/networking/networking.go
+++ b/platform/infra-pulumi/base/pkg/networking/networking.go
@@ -23,7 +23,28 @@ type Result struct {
 	PrivateSubnetIds pulumi.StringArrayOutput
 }
 
+// NewNetworking provisions a "real" VPC network layout suitable for ECS/Fargate:
+//
+// High-level:
+//  1. Create a VPC with DNS enabled
+//  2. Attach an Internet Gateway (public internet egress/ingress for public subnets) making it possible for the internet to reach resources that are in private subnets yet connected to the IGW
+//  3. Discover Availability Zones and spread subnets across them (basic HA)
+//  4. Split the VPC CIDR into N public + N private subnet CIDRs
+//  5. Create public subnets (auto-assign public IPs) + private subnets (no public IPs)
+//  6. Create a single NAT Gateway (in the first public subnet) so private subnets can reach the internet
+//     for things like ECR pulls, OS package downloads, etc.
+//  7. Create route tables:
+//     - public RT: 0.0.0.0/0 -> IGW
+//     - private RT: 0.0.0.0/0 -> NAT
+//  8. Associate the appropriate RT to each subnet
+//
+// Returns the VPC ID and subnet IDs as outputs to be consumed by the rest of the stack.
 func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Result, error) {
+	// --- VPC ---
+	// Creates the VPC "container" that all networking resources live inside.
+	// DNS support/hostnames are important for ALBs, private DNS, ECS, etc.
+	// This allows you to create ALBs (Application Load Balancers) to point to DNS names, i.e. app.fs0ciety.dev and api.fs0ciety.dev and have them work smoothly
+	// Instead of having to use IP addresses, which are not as user friendly and easy to remember and frequently changing.
 	name := fmt.Sprintf("%s-%s-vpc", projectName, n.Environment)
 	vpc, err := ec2.NewVpc(ctx, name, &ec2.VpcArgs{
 		CidrBlock:          pulumi.String(n.VpcCidr),
@@ -38,6 +59,16 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		return nil, err
 	}
 
+	// --- Internet Gateway (IGW) ---
+	// Required for public subnets to have direct internet access.
+	// This IGW will be used to route traffic coming in and going out of the VPC to the internet.
+	// Example: A user goes to our website app.fs0ciety.dev, that traffic is redirected by the IGW to the private subent of the ECS resource
+	// An internet gateway enables resources in your public subnets (such as EC2 instances) to connect to the internet
+	// if the resource has a public IPv4 address or an IPv6 address.
+	// Similarly, resources on the internet can initiate a connection to resources in your subnet using the
+	// public IPv4 address or IPv6 address. For example, an internet gateway
+	// enables you to connect to an EC2 instance in AWS using your local computer.
+	// See more here: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html
 	name = fmt.Sprintf("%s-%s-igw", projectName, n.Environment)
 	igw, err := ec2.NewInternetGateway(ctx, name, &ec2.InternetGatewayArgs{
 		VpcId: vpc.ID(),
@@ -50,30 +81,63 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		return nil, err
 	}
 
+	// --- Availability Zones (AZs) ---
+	// We distribute both public and private subnets across AZs for basic fault tolerance.
 	azs, err := aws.GetAvailabilityZones(ctx, &aws.GetAvailabilityZonesArgs{
 		State: pulumi.StringRef("available"),
 	}, nil)
 	if err != nil {
 		return nil, err
 	}
+	// Many production patterns assume at least 2 AZs.
 	if len(azs.Names) < 2 {
 		return nil, fmt.Errorf("need at least 2 AZs, found %d", len(azs.Names))
 	}
+
+	// --- CIDR planning ---
+	// Split the VPC CIDR into (publicCount + privateCount) smaller CIDR blocks.
+	// We then use the first N for public subnets and the rest for private subnets.
+	// IP addresses enabl10.0.0.0/16 represents 65,536 IPv4 addresses from 10.0.0.0 to 10.0.255.255.
+	// Example: 10.0.0.0/16 represents 65,536 IPv4 addresses from 10.0.0.0 to 10.0.255.255.
+	// The first 256 addresses (10.0.0.0/24) are used for the public subnets, and the remaining 65,280 addresses (10.0.1.0/24 to 10.0.255.255/24) are used for the private subnets.
+	// This is a common pattern for VPCs, and it is a good way to ensure that the subnets are evenly distributed across the AZs.
+	// See more here: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html
 
 	publicCidrs, privateCidrs, err := splitCidr(ctx, n.VpcCidr, n.NewBits, n.PublicCount, n.PrivateCount)
 	if err != nil {
 		return nil, err
 	}
 
+	// Keep references to created subnets so we can:
+	// - attach NAT into a public subnet
+	// - associate route tables
+	// - return subnet IDs as outputs
 	publicSubnets := make([]*ec2.Subnet, 0, n.PublicCount)
 	privateSubnets := make([]*ec2.Subnet, 0, n.PrivateCount)
 
+	// --- Public subnets ---
+	// Public subnets:
+	// - have a route to the IGW (via public route table below)
+	// - map public IPs on launch for instances/tasks that need direct internet reachability
+	// This is useful for the following use cases:
+	// - ECS tasks that need to reach the internet
+	// - ECS tasks that need to reach the internet
+	// What actually lives in private subnets?
+	// Always private
+	// RDS
+	// ECS services
+	// Internal workers
+	// Redis / OpenSearch / etc.
+	// Usually public
+	// ALB	(Application Load Balancer)
+	// NAT Gateway	(Network Address Translation Gateway)
+	// Bastion / SSM access instance (if you have one)	(A bastion host is a server that allows you to securely connect to other servers in your VPC.)
 	for i := 0; i < n.PublicCount; i++ {
 		name = fmt.Sprintf("%s-%s-public-%d", projectName, n.Environment, i+1)
 		sn, err := ec2.NewSubnet(ctx, name, &ec2.SubnetArgs{
 			VpcId:               vpc.ID(),
 			CidrBlock:           pulumi.String(publicCidrs[i]),
-			AvailabilityZone:    pulumi.String(azs.Names[i%len(azs.Names)]),
+			AvailabilityZone:    pulumi.String(azs.Names[i%len(azs.Names)]), // round-robin which subnet goes to which AZ
 			MapPublicIpOnLaunch: pulumi.Bool(true),
 			Tags: pulumi.StringMap{
 				"Name":        pulumi.String(name),
@@ -86,12 +150,16 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		publicSubnets = append(publicSubnets, sn)
 	}
 
+	// --- Private subnets ---
+	// Private subnets:
+	// - do NOT auto-assign public IPs
+	// - will route outbound internet traffic through NAT (via private route table below)
 	for i := 0; i < n.PrivateCount; i++ {
 		name = fmt.Sprintf("%s-%s-private-%d", projectName, n.Environment, i+1)
 		sn, err := ec2.NewSubnet(ctx, name, &ec2.SubnetArgs{
 			VpcId:            vpc.ID(),
 			CidrBlock:        pulumi.String(privateCidrs[i]),
-			AvailabilityZone: pulumi.String(azs.Names[i%len(azs.Names)]),
+			AvailabilityZone: pulumi.String(azs.Names[i%len(azs.Names)]), // round-robin which subnet goes to which AZ
 			Tags: pulumi.StringMap{
 				"Name":        pulumi.String(name),
 				"Environment": pulumi.String(n.Environment),
@@ -103,7 +171,14 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		privateSubnets = append(privateSubnets, sn)
 	}
 
-	// NAT in first public subnet
+	// --- NAT Gateway ---
+	// A NAT Gateway allows resources in private subnets to reach the public internet
+	// WITHOUT exposing them to inbound public traffic.
+	// This is useful for the following use cases:
+	// - Connecting your computer to the RDS instance in the private subnet (i.e from my computer I ssm tunnel into a bastion host in the private subnet, that bastion host port forwards me to the RDS instance)
+	// - Allowing an ECS backend container to send a response to an Auth0 webhook / API call
+	// Note: this creates a single NAT in the first public subnet (cost-effective because NAT gateways are expensive, more expensive is one NAT per AZ).
+	// More HA (and more expensive) is one NAT per AZ.
 	name = fmt.Sprintf("%s-%s-nat-eip", projectName, n.Environment)
 	eip, err := ec2.NewEip(ctx, name, &ec2.EipArgs{
 		Domain: pulumi.String("vpc"),
@@ -119,7 +194,7 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 	name = fmt.Sprintf("%s-%s-nat-gateway", projectName, n.Environment)
 	nat, err := ec2.NewNatGateway(ctx, name, &ec2.NatGatewayArgs{
 		AllocationId: eip.ID(),
-		SubnetId:     publicSubnets[0].ID(),
+		SubnetId:     publicSubnets[0].ID(), // NAT lives in a public subnet
 		Tags: pulumi.StringMap{
 			"Name":        pulumi.String(name),
 			"Environment": pulumi.String(n.Environment),
@@ -129,6 +204,11 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		return nil, err
 	}
 
+	// --- Route tables ---
+	// Public route table: default route -> IGW
+	// Route tables control egress (outbound) traffic decisions. 
+
+	// This route table enables resources in private subnets to reach the internet.
 	name = fmt.Sprintf("%s-%s-public-rt", projectName, n.Environment)
 	publicRt, err := ec2.NewRouteTable(ctx, name, &ec2.RouteTableArgs{
 		VpcId: vpc.ID(),
@@ -151,6 +231,7 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		return nil, err
 	}
 
+	// Private route table: default route -> NAT
 	name = fmt.Sprintf("%s-%s-private-rt", projectName, n.Environment)
 	privateRt, err := ec2.NewRouteTable(ctx, name, &ec2.RouteTableArgs{
 		VpcId: vpc.ID(),
@@ -173,6 +254,8 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		return nil, err
 	}
 
+	// --- Route table associations ---
+	// Bind every public subnet to the public route table and every private subnet to the private route table.
 	for i := 0; i < len(publicSubnets); i++ {
 		name = fmt.Sprintf("%s-%s-public-assoc-%d", projectName, n.Environment, i+1)
 		_, err = ec2.NewRouteTableAssociation(ctx, name, &ec2.RouteTableAssociationArgs{
@@ -194,6 +277,8 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 		}
 	}
 
+	// --- Collect IDs for outputs ---
+	// We return IDs rather than concrete resource pointers so other stacks/modules can consume them cleanly.
 	pubIds := pulumi.StringArray{}
 	for _, s := range publicSubnets {
 		pubIds = append(pubIds, s.ID())
@@ -210,7 +295,15 @@ func NewNetworking(ctx *pulumi.Context, projectName string, n Networking) (*Resu
 	}, nil
 }
 
-// returns []string CIDRs
+// splitCidr deterministically splits a base CIDR into smaller subnets.
+//
+// Example intuition:
+// - base = "10.0.0.0/16"
+// - newBits = 8  => creates /24 subnets
+// - total = publicCount + privateCount
+//
+// We generate `total` CIDRs using cidrsubnet(base, newBits, netnum) for netnum in [0..total-1].
+// The first `publicCount` CIDRs are returned as public subnet CIDRs; the remainder are private subnet CIDRs.
 func splitCidr(ctx *pulumi.Context, base string, newBits, publicCount, privateCount int) ([]string, []string, error) {
 	total := publicCount + privateCount
 	all := make([]string, 0, total)

--- a/platform/infra-pulumi/services/Pulumi.prod.yaml
+++ b/platform/infra-pulumi/services/Pulumi.prod.yaml
@@ -1,5 +1,5 @@
 config:
   fs0ciety-services:awsRegion: us-east-1
   fs0ciety-services:baseStack: rasha-hantash-org/fs0cietybase/prod
-  fs0ciety-services:frontendImage: 891377123668.dkr.ecr.us-east-1.amazonaws.com/fs0ciety-prod:frontend-preview-2026-01-03_21H55M-81bf2b8
-  fs0ciety-services:backendImage: 891377123668.dkr.ecr.us-east-1.amazonaws.com/fs0ciety-prod:backend-preview-2026-01-03_21H55M-81bf2b8
+  fs0ciety-services:frontendImageTag: frontend-2026-01-04_21H43M-81c63b7
+  fs0ciety-services:backendImageTag: backend-2026-01-04_21H43M-81c63b7

--- a/platform/infra-pulumi/services/main.go
+++ b/platform/infra-pulumi/services/main.go
@@ -25,6 +25,9 @@ type baseOutputs struct {
 	// Target groups created in base ALB module
 	frontendTargetGroupArn pulumi.StringOutput
 	backendTargetGroupArn  pulumi.StringOutput
+
+	// ECR repository URL
+	ecrRepoUrl pulumi.StringOutput
 }
 
 func main() {
@@ -43,11 +46,15 @@ func main() {
 		}
 		base := loadBaseOutputs(baseRef)
 
+		// ecrRepoUrl := baseRef.GetOutput(pulumi.String("ecrRepoUrl"))
+
+
+
 		// ✅ These should match what your Taskfile sets:
 		// pulumi config set frontendImage <full_ecr_uri:tag>
 		// pulumi config set backendImage <full_ecr_uri:tag>
-		frontendImage := cfg.Require("frontendImage")
-		backendImage := cfg.Require("backendImage")
+		frontendImage := pulumi.Sprintf("%s:%s", base.ecrRepoUrl, cfg.Require("frontendImageTag"))
+		backendImage := pulumi.Sprintf("%s:%s", base.ecrRepoUrl, cfg.Require("backendImageTag"))
 
 		// Log groups
 		feLogs, err := cloudwatch.NewLogGroup(ctx, "frontend-logs", &cloudwatch.LogGroupArgs{
@@ -195,8 +202,8 @@ func main() {
 		}
 
 		// Helpful exports
-		ctx.Export("frontendImage", pulumi.String(frontendImage))
-		ctx.Export("backendImage", pulumi.String(backendImage))
+		ctx.Export("frontendImage", frontendImage)
+		ctx.Export("backendImage", backendImage)
 		ctx.Export("frontendServiceName", feSvc.Name)
 		ctx.Export("backendServiceName", beSvc.Name)
 
@@ -214,6 +221,7 @@ func loadBaseOutputs(ref *pulumi.StackReference) baseOutputs {
 		backendSgId:            requireString(ref, "backendSgId"),
 		frontendTargetGroupArn: requireString(ref, "frontendTargetGroupArn"),
 		backendTargetGroupArn:  requireString(ref, "backendTargetGroupArn"),
+		ecrRepoUrl:            requireString(ref, "ecrRepoUrl"),
 	}
 }
 


### PR DESCRIPTION
### TL;DR

Updated AWS secret naming convention to use a dynamic project name instead of hardcoded "traba" prefix.

### What changed?

- Modified the secret ID format in both frontend and backend code to use `${projectName}-${environment}-core-config` instead of hardcoded `traba-${environment}-frontend-config` or `traba-${environment}-backend-config`
- Added support for the `PROJECT_NAME` environment variable in all relevant files
- Added a fallback to "traba" when `PROJECT_NAME` is not set in the backend config

### How to test?

1. Set the `PROJECT_NAME` environment variable to a custom value
2. Ensure AWS secrets are properly configured with the new naming pattern
3. Verify that the application can retrieve secrets correctly with the new naming convention
4. Test with `PROJECT_NAME` unset to confirm fallback to "traba" works as expected

### Why make this change?

This change makes the codebase more flexible by removing hardcoded project name references, allowing the same code to be used across different projects or environments with different naming conventions. It also standardizes on a consistent "core-config" suffix instead of separate "frontend-config" and "backend-config" secrets.